### PR TITLE
Adds the PathExtractor.matchCurrentValue API, allowing users to matchonly the value at which the IonReader is currently positioned.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,7 +31,7 @@ buildscript {
 plugins {
     id "java"
     id "checkstyle"
-    id "org.jetbrains.kotlin.jvm" version "1.3.21"
+    id "org.jetbrains.kotlin.jvm" version "1.4.10"
 
     // benchmark
     id "me.champeau.gradle.jmh" version "0.4.8"

--- a/src/main/java/com/amazon/ionpathextraction/PathExtractor.java
+++ b/src/main/java/com/amazon/ionpathextraction/PathExtractor.java
@@ -50,4 +50,25 @@ public interface PathExtractor<T> {
      * @param context context passed in to callback functions.
      */
     void match(final IonReader reader, final T context);
+
+    /**
+     * Behaves identically to {@link #match(IonReader)}, except that only the value at which the given reader is
+     * currently positioned is evaluated against the registered search paths. Before this method is called, the caller
+     * must position the reader on the value to be searched using {@link IonReader#next()}. After this method returns,
+     * it is the caller's responsibility to call {@link IonReader#next()} to position the reader on the next value at
+     * the same depth.
+     * @param reader {@link IonReader}, already positioned on a value, to process.
+     */
+    void matchCurrentValue(final IonReader reader);
+
+    /**
+     * Behaves identically to {@link #match(IonReader, T)}, except that only the value at which the given reader is
+     * currently positioned is evaluated against the registered search paths. Before this method is called, the caller
+     * must position the given reader on the value to be searched using {@link IonReader#next()}. After this method
+     * returns, it is the caller's responsibility to call {@link IonReader#next()} to position the reader on the next
+     * value at the same depth.
+     * @param reader {@link IonReader}, already positioned on a value, to process.
+     * @param context context passed in to callback functions.
+     */
+    void matchCurrentValue(final IonReader reader, final T context);
 }


### PR DESCRIPTION
*Issue #, if available:*
#16 

*Description of changes:*
Does not consume all values from the IonReader in a single call, giving the user more control over the IonReader. This gives users the ability to utilize path extraction for a subset of an Ion stream.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
