### PR TITLE
Fixes a bug that caused an error when evaluating a second path against a binary Ion value that matched a previous path.

### DIFF
--- a/src/main/java/com/amazon/ionpathextraction/PathExtractorImpl.java
+++ b/src/main/java/com/amazon/ionpathextraction/PathExtractorImpl.java
@@ -106,8 +106,8 @@ final class PathExtractorImpl<T> implements PathExtractor<T> {
         // will continue to next depth
         final List<SearchPath<T>> partialMatches = new ArrayList<>();
 
+        final MatchContext matchContext = new MatchContext(reader, currentDepth, readerContainerIndex, config);
         for (SearchPath<T> sp : tracker.activePaths()) {
-            final MatchContext matchContext = new MatchContext(reader, currentDepth, readerContainerIndex, config);
             // a terminal search path is at the last path component meaning that if this search path partially
             // matches it will be a full match and the callback must be invoked
             boolean searchPathIsTerminal = isTerminal(tracker.getCurrentDepth(), sp);


### PR DESCRIPTION
*Description of changes:*
Before this change, the added unit test failed for binary Ion data. That's because the `MatchContext` constructor calls `IonReader.getTypeAnnotations()`. The behavior of that method is undefined when the reader is not positioned at the start of a value. The binary reader throws an exception, while the text reader does not.

There are two registered paths, and they are evaluated in the order they are registered. On the second value in the struct (`col2`), the `(col2)` path matches. During the callback, the matching value is fully consumed, leaving the reader positioned after the value but *not* positioned on the next value.

After the callback returns, the reader remains at the same depth and attempts to evaluate the `(col1)` path against the same value. However, since it's the same value, neither the annotations nor any other aspect of the value can have changed. Calling `IonReader.getTypeAnnotations()` at that point would have undefined behavior, but it turns out it's not even necessary. A single `MatchContext` instance can be used for all of the path evaluations on a given value.

This results in `IonReader.getTypeAnnotations()` only being called when the reader is positioned before the start of a potentially-matching value, where the behavior of the invocation is well-defined.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
