### PR TITLE
Upgrade Checkstyle 8.{18=>37}

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -90,7 +90,7 @@ jmh {
 }
 
 checkstyle {
-    toolVersion = "8.18"
+    toolVersion = "8.37"
     ignoreFailures = false
     maxWarnings = 0
     maxErrors = 0

--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -36,6 +36,10 @@
     <property name="fileExtensions" value="java,kt" />
   </module>
 
+  <module name="LineLength">
+    <property name="max" value="120"/>
+    <property name="ignorePattern" value="^package.*|^import.*|a href|href|http://|https://|ftp://"/>
+  </module>
   <module name="TreeWalker">
     <module name="SuppressionCommentFilter" /> <!-- allows for CHECKSTYLE:OFF comments -->
     <module name="OuterTypeFilename"/>
@@ -50,10 +54,6 @@
       <property name="allowEscapesForControlCharacters" value="true"/>
       <property name="allowByTailComment" value="true"/>
       <property name="allowNonPrintableEscapes" value="true"/>
-    </module>
-    <module name="LineLength">
-      <property name="max" value="120"/>
-      <property name="ignorePattern" value="^package.*|^import.*|a href|href|http://|https://|ftp://"/>
     </module>
     <module name="AvoidStarImport"/>
     <module name="OneTopLevelClass"/>
@@ -238,15 +238,17 @@
       <property name="target"
         value="CLASS_DEF, INTERFACE_DEF, ENUM_DEF, METHOD_DEF, CTOR_DEF, VARIABLE_DEF"/>
     </module>
+    <module name="MissingJavadocMethodCheck">
+      <property name="minLineCount" value="2"/>
+      <property name="ignoreMethodNamesRegex" value="(g|s)et[a-z0-9][a-zA-Z0-9_]*"/> <!-- getters and setters -->
+      <property name="allowedAnnotations" value="Override, Test"/>
+    </module>
     <module name="JavadocMethod">
       <property name="scope" value="public"/>
       <property name="allowMissingParamTags" value="true"/>
-      <property name="allowMissingThrowsTags" value="true"/>
+      <property name="validateThrows" value="false"/>
       <property name="allowMissingReturnTag" value="true"/>
-      <property name="minLineCount" value="2"/>
       <property name="allowedAnnotations" value="Override, Test"/>
-      <property name="allowThrowsTagsForSubclasses" value="true"/>
-      <property name="ignoreMethodNamesRegex" value="(g|s)et[a-z0-9][a-zA-Z0-9_]*"/> <!-- getters and setters -->
     </module>
     <module name="MethodName">
       <property name="format" value="^[a-z][a-z0-9][a-zA-Z0-9_]*$"/>


### PR DESCRIPTION
`LineLength` is no longer a child of `TreeWalk`, but now belongs under `Checker`

Some `JavadocMethodCheck` parameters are now moved to `MissingJavadocMethodCheck`:
* https://checkstyle.org/releasenotes.html#Release_8.25

`{allowMissingThrows=true, allowThrowsTagsForSubclasses=true}` is now `validateThrows=false`
* https://checkstyle.sourceforge.io/apidocs/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheck.html

*Issue #, if available:* https://github.com/amzn/ion-java-path-extraction/issues/22

*Description of changes:* Resolves #22, and hopefully buys us a bit more time away from Checkstyle issues by moving to the latest available version. 

Tested by `gradle build`, which succeeds after these changes.
```plain
gradle build
```
```plain
Deprecated Gradle features were used in this build, making it incompatible with Gradle 7.0.
Use '--warning-mode all' to show the individual deprecation warnings.
See https://docs.gradle.org/6.7.1/userguide/command_line_interface.html#sec:command_line_warnings

BUILD SUCCESSFUL in 755ms
12 actionable tasks: 12 up-to-date
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
