### PR TITLE
Set Version to 1.5.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -49,7 +49,7 @@ repositories {
 
 group 'com.amazon.ion'
 archivesBaseName = 'ion-java-path-extraction'
-version '1.5.0-SNAPSHOT'
+version '1.5.0'
 
 sourceCompatibility = 1.8
 


### PR DESCRIPTION
Prepare for a 1.5.0 release. This will contain:
- bug fix for the case-insensitive field name matcher for strict mode
- simpler builder API for programmatic callers
- strict typing mode for the strict matcher

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
